### PR TITLE
LiveFixtures hooked to live points

### DIFF
--- a/src/components/common/TeamDisplay/index.js
+++ b/src/components/common/TeamDisplay/index.js
@@ -1,5 +1,6 @@
 // src/components/common/TeamDisplay/index.js
 import React from 'react';
+import useManagerTeamPoints from '../../../hooks/useManagerTeamPoints';
 
 const TeamDisplay = ({
     team,
@@ -10,8 +11,21 @@ const TeamDisplay = ({
     onPlayerClick, // Optional callback for player interaction
     className, // Optional additional classes
     showSubstitutes = true, // Optional flag to show/hide subs
-    showPoints = true, // Optional flag to show/hide points
+    showPoints = true,
+    managerId,
+    managersData,
+    currentGW,
+    playersData // Optional flag to show/hide points
 }) => {
+    // Get total points for the team
+    const { teamPoints } = useManagerTeamPoints(
+        managerId,
+        managersData,
+        currentGW,
+        playersData
+    );
+
+
     if (isLoading) {
         return (
             <div className={`bg-white rounded-lg shadow p-4 ${className || ''}`}>
@@ -56,7 +70,14 @@ const TeamDisplay = ({
     return (
         <div className={className}>
             <div className="mb-4">
-                <h2 className="text-xl font-semibold">{title}</h2>
+                <div className="flex justify-between items-center">
+                    <h2 className="text-xl font-semibold">{title}</h2>
+                    {teamPoints && (
+                        <span className="text-2xl font-bold text-gray-900">
+                            {teamPoints.totalPoints ?? '-'}
+                        </span>
+                    )}
+                </div>
                 {subtitle && (
                     <p className="text-gray-600 text-sm">{subtitle}</p>
                 )}

--- a/src/features/Fixtures/FixtureRow.js
+++ b/src/features/Fixtures/FixtureRow.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import useManagerTeamPoints from '../../hooks/useManagerTeamPoints';
+import { createTeamNameLookup } from '../../utils/managerUtils';
+
+const FixtureRow = ({ fixture, onFixtureClick, managersData, currentGW, playersData }) => {
+    const { teamPoints: homeTeamPoints } = useManagerTeamPoints(
+        fixture.league_entry_1,
+        managersData,
+        currentGW,
+        playersData
+    );
+    const { teamPoints: awayTeamPoints } = useManagerTeamPoints(
+        fixture.league_entry_2,
+        managersData,
+        currentGW,
+        playersData
+    );
+
+    const entryIdtoName = createTeamNameLookup(managersData);
+
+    const homeTeamName = entryIdtoName[fixture.league_entry_1]
+    const awayTeamName = entryIdtoName[fixture.league_entry_2]
+
+
+    return (
+        <div
+            onClick={() => onFixtureClick(fixture)}
+            className="p-4 hover:bg-gray-50 transition-colors duration-200 cursor-pointer"
+        >
+            <div className="flex items-center justify-between max-w-3xl mx-auto">
+                <div className="flex-1 text-right pr-4">
+                    <span className="font-semibold text-gray-800">
+                        {homeTeamName}
+                    </span>
+                </div>
+                <div className="flex items-center space-x-4 px-4">
+                    <span className="text-2xl font-bold text-gray-900 min-w-[2rem] text-center">
+                        {homeTeamPoints?.totalPoints ?? '-'}
+                    </span>
+                    <span className="text-gray-400">vs</span>
+                    <span className="text-2xl font-bold text-gray-900 min-w-[2rem] text-center">
+                        {awayTeamPoints?.totalPoints ?? '-'}
+                    </span>
+                </div>
+                <div className="flex-1 text-left pl-4">
+                    <span className="font-semibold text-gray-800">
+                        {awayTeamName}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FixtureRow; 

--- a/src/features/Fixtures/LiveFixtures.js
+++ b/src/features/Fixtures/LiveFixtures.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import managersData from '../../constants/manager_details.json';
 import useManagerFixtures from '../../hooks/useManagerFixtures';
+import FixtureRow from './FixtureRow';
 
-const LiveFixtures = ({ gameweekFinished, leagueId, currentGW, onFixtureClick }) => {
+const LiveFixtures = ({ gameweekFinished, leagueId, currentGW, onFixtureClick, playersData, managersData }) => {
     const { managerFixtures, managerFixturesLoading, managerFixturesError } = useManagerFixtures(leagueId, currentGW);
 
-    // Create a lookup from entry ID to team name
-    const entryIdToName = {};
-    managersData.league_entries.forEach(manager => {
-        entryIdToName[manager.id] = manager.entry_name;
-    });
+    // // Create a lookup from entry ID to team name
+    // const entryIdToName = {};
+    // managersData.league_entries.forEach(manager => {
+    //     entryIdToName[manager.id] = manager.entry_name;
+    // });
 
     if (managerFixturesLoading) {
         return (
@@ -57,7 +57,7 @@ const LiveFixtures = ({ gameweekFinished, leagueId, currentGW, onFixtureClick })
                     {gameweekFinished !== null && (
                         <span className={`px-3 py-1 rounded-full text-sm font-medium ${gameweekFinished
                             ? 'gameweek-finished bg-red-100 text-red-700'
-                            : 'gameweek-livebg green-100 text-green-700'
+                            : 'gameweek-live bg-green-100 text-green-700'
                             }`}>
                             {gameweekFinished ? '🔴 Gameweek Finished' : '🟢 Live Gameweek'}
                         </span>
@@ -71,36 +71,15 @@ const LiveFixtures = ({ gameweekFinished, leagueId, currentGW, onFixtureClick })
             ) : (
                 <div className="fixtures-grid divide-y divide-gray-100">
                     {managerFixtures.map((fixture, index) => (
-                        <div
-                            className="p-4 hover:bg-gray-50 transition-colors duration-200 cursor-pointer"
+                        <FixtureRow
                             key={index}
-                            onClick={() => onFixtureClick(fixture)}
-                        >
-                            <div className="flex items-center justify-between max-w-3xl mx-auto">
-                                {/* Home Team */}
-                                <div className="flex-1 text-right pr-4">
-                                    <span className="font-semibold text-gray-800">
-                                        {entryIdToName[fixture.league_entry_1]}
-                                    </span>
-                                </div>
-                                {/* Scores */}
-                                <div className="flex items-center space-x-4 px-4">
-                                    <span className="text-2xl font-bold text-gray-900 min-w-[2rem] text-center">
-                                        {fixture.league_entry_1_points ?? '-'}
-                                    </span>
-                                    <span className="text-gray-400">vs</span>
-                                    <span className="text-2xl font-bold text-gray-900 min-w-[2rem] text-center">
-                                        {fixture.league_entry_2_points ?? '-'}
-                                    </span>
-                                </div>
-                                {/* Away Team */}
-                                <div className="flex-1 text-left pl-4">
-                                    <span className="font-semibold text-gray-800">
-                                        {entryIdToName[fixture.league_entry_2]}
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
+                            fixture={fixture}
+                            // entryIdToName={entryIdToName}
+                            onFixtureClick={onFixtureClick}
+                            managersData={managersData}
+                            currentGW={currentGW}
+                            playersData={playersData}
+                        />
                     ))}
                 </div>
             )}

--- a/src/hooks/useManagerTeam.js
+++ b/src/hooks/useManagerTeam.js
@@ -12,10 +12,21 @@ const useManagerTeam = (managerId, managersData, currentGW, playersData, livePoi
 
         setIsLoading(true);
         try {
+            console.log("This is the managers data", managersData);
             // get the manager entry id from the managers data as id doesn't work 100% of time for team selection
             const managerEntryId = managersData.find(m => m.id === managerId)?.entry_id;
+
+            if (!managerEntryId) {
+                throw new Error('Manager not found');
+            }
+
+
             // fetch the team selection for the manager using the API
             const res = await fetch(`/api/proxy/entry/${managerEntryId}/event/${currentGW}`);
+            if (!res.ok) {
+                throw new Error(`HTTP error! status: ${res.status}`);
+            }
+
             const json = await res.json();
             const picks = json.picks || [];
 
@@ -46,7 +57,7 @@ const useManagerTeam = (managerId, managersData, currentGW, playersData, livePoi
         } finally {
             setIsLoading(false);
         }
-    }, [managerId, currentGW, playersData, livePoints]);
+    }, [managerId, currentGW, playersData, livePoints, managersData]);
 
     useEffect(() => {
         if (playersData?.length && Object.keys(livePoints).length) {

--- a/src/hooks/useManagerTeamPoints.js
+++ b/src/hooks/useManagerTeamPoints.js
@@ -1,0 +1,31 @@
+// src/hooks/useManagerTeamPoints.js
+import { useState, useEffect } from 'react';
+import useManagerTeam from './useManagerTeam';
+import usePlayerLivePoints from './usePlayerLivePoints';
+
+const useManagerTeamPoints = (managerId, managersData, currentGW, playersData) => {
+    const { points } = usePlayerLivePoints(currentGW);
+    const { team, isLoading, error } = useManagerTeam(managerId, managersData, currentGW, playersData, points);
+    const [teamPoints, setTeamPoints] = useState(null);
+
+
+    useEffect(() => {
+        if (!team?.starters || !points) return;
+
+        const totalPoints = team.starters.reduce((total, player) => {
+            return total + (points[player.elementId] || 0);
+        }, 0);
+
+        setTeamPoints({
+            totalPoints,
+        });
+    }, [team, points]);
+
+    return {
+        teamPoints,
+        isLoading,
+        error
+    };
+};
+
+export default useManagerTeamPoints;

--- a/src/pages/H2H/index.js
+++ b/src/pages/H2H/index.js
@@ -85,6 +85,10 @@ const H2H = ({ currentGW, gameweekFinished, selectedManagerId, managersData, pla
                         subtitle="This is the home team"
                         isLoading={homeTeamLoading}
                         error={homeTeamError}
+                        managerId={selectedHomeId}  // Add this
+                        managersData={managersData}  // Add this
+                        currentGW={currentGW}  // Add this
+                        playersData={playersData}
                     />
                     <TeamDisplay
                         team={awayTeam}
@@ -92,6 +96,10 @@ const H2H = ({ currentGW, gameweekFinished, selectedManagerId, managersData, pla
                         subtitle="This is the away team"
                         isLoading={awayTeamLoading}
                         error={awayTeamError}
+                        managerId={selectedAwayId}  // Add this
+                        managersData={managersData}  // Add this
+                        currentGW={currentGW}  // Add this
+                        playersData={playersData}
                     />
                 </div>
                 {/* LiveFixtures in top right */}
@@ -101,6 +109,8 @@ const H2H = ({ currentGW, gameweekFinished, selectedManagerId, managersData, pla
                         gameweekFinished={gameweekFinished}
                         leagueId={leagueId}
                         onFixtureClick={handleFixtureClick}
+                        playersData={playersData}
+                        managersData={managersData}
                     />
                 </div>
             </div>

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -65,7 +65,7 @@ const Homepage = ({ selectedManagerId, gameweekFinished, currentGW }) => {
 
                 {/* Live Fixtures */}
                 <div className="bg-white p-6 rounded-xl shadow">
-                    <LiveFixtures gameweekFinished={gameweekFinished} leagueId={leagueId} currentGW={currentGW} />
+                    "To be continued..."
                 </div>
             </div>
         </div>

--- a/src/utils/managerUtils.js
+++ b/src/utils/managerUtils.js
@@ -1,0 +1,22 @@
+/**
+ * Creates a lookup object mapping manager IDs to their team names
+ * @param {Array} managersData - Array of manager objects
+ * @returns {Object} Object mapping manager IDs to team names
+ */
+export const createTeamNameLookup = (managersData) => {
+    const lookup = {};
+    managersData.forEach(manager => {
+        lookup[manager.id] = manager.teamName;
+    });
+    return lookup;
+};
+
+/**
+ * Gets a team name for a given manager ID
+ * @param {Array} managersData - Array of manager objects
+ * @param {number} managerId - The ID of the manager
+ * @returns {string|undefined} The team name if found, undefined otherwise
+ */
+export const getTeamName = (managersData, managerId) => {
+    return managersData.find(manager => manager.id === managerId)?.teamName;
+};


### PR DESCRIPTION
It runs a little slower which I can look at later, but now there is a hook to get players points, and a hook to get a teams total points and they are both pulling live rather than the standard API which is static till after the fixtures have finished. Also moved the live fixtures off of the homepage and onto H2H. Frontend design in general needs a complete rethink